### PR TITLE
feat: добавить блок инфо на страницу Оценка работы волонтера/Оценка

### DIFF
--- a/src/blocks/paragraph/_style/paragraph_style_info.css
+++ b/src/blocks/paragraph/_style/paragraph_style_info.css
@@ -1,0 +1,3 @@
+.paragraph_style_info {
+  padding-bottom: 0;
+}

--- a/src/lk-volunteer-rate.html
+++ b/src/lk-volunteer-rate.html
@@ -163,6 +163,12 @@
         <p class="paragraph">Если вам понравилось работать с волонтером, вы можете добавить его в список «Проверенные волонтеры». Этим волонтерам будут приходить оповещения о ваших новых заданиях по их специализации — так будет больше шансов поработать с ними снова.</p>        
         <button type="button" class="btn btn_style_dark btn_position_right">Добавить</button>
       </fieldset>
+      <fieldset class="fieldset fieldset_template_grid-one-col">
+        <div class="information">
+          <img src="<%=require('./images/warning.svg')%>" alt="information" class="information__icon">
+          <p class="paragraph paragraph_style_info">Вы можете попросить волонтера не публиковать результат работы, если считаете, что он содержит конфиденциальные данные</p>
+        </div>
+      </fieldset>
       <fieldset class="fieldset fieldset_template_grid-form fieldset_style_p-none">
         <button type="submit" class="btn btn_style_primary">Оценить</button>
         <button type="button" class="btn btn_style_secondary btn_position_right">Отмена</button>

--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -355,6 +355,7 @@
 @import url(./../blocks/paragraph/_style/paragraph_style_desktop.css);
 @import url(./../blocks/paragraph/_style/paragraph_style_mobile.css);
 @import url(./../blocks/paragraph/_style/paragraph_style_rate.css);
+@import url(./../blocks/paragraph/_style/paragraph_style_info.css);
 
 @import url(../blocks/list/list.css);
 @import url(../blocks/list/__item/list__item.css);

--- a/src/ui-kit.html
+++ b/src/ui-kit.html
@@ -375,7 +375,7 @@
 <fieldset class="fieldset fieldset_template_grid-one-col">
   <div class="information">
     <img src="<%=require('./images/warning.svg')%>" alt="information" class="information__icon">
-    <p class="paragraph">Вы можете попросить волонтера не публиковать результат работы, если считаете, что он содержит конфиденциальные данные</p>
+    <p class="paragraph paragraph_style_info">Вы можете попросить волонтера не публиковать результат работы, если считаете, что он содержит конфиденциальные данные</p>
   </div>
 </fieldset>
 


### PR DESCRIPTION
feat/volunteer-rate-information: добавила в разметку блок с информацией.
Предварительно чуть скорректировала стили блока с информацией: добавила модификатор paragraph_style_info для того, чтобы избавиться от нижнего паддинга, которого  в случае с блоком информации в макете нет.