### PR TITLE
fix: поправить стили main и fieldset для корректировки нижнего отступа

### DIFF
--- a/src/blocks/main/_template/main_template_lk-issues.css
+++ b/src/blocks/main/_template/main_template_lk-issues.css
@@ -1,0 +1,13 @@
+.main_template_lk-issues {
+  grid-template-columns: 256px minmax(min-content, 736px);
+  grid-template-rows: repeat(2, minmax(min-content, max-content));
+}
+
+@media screen and (max-width: 900px) {
+  .main_template_lk-issues {
+    grid-template-columns: 1fr;
+    grid-template-rows: repeat(2, minmax(min-content, max-content));
+    padding-bottom: 80px;
+    row-gap: 32px;
+  }
+}

--- a/src/lk-fund-hours.html
+++ b/src/lk-fund-hours.html
@@ -47,7 +47,7 @@
             </a>
         </div>
     </header>
-    <main class="main main_template_lk">
+    <main class="main main_template_lk-issues">
         <nav class="breadcrumbs">
             <ul class="breadcrumbs__list">
                 <li class="breadcrumbs__item">

--- a/src/lk-fund-rate.html
+++ b/src/lk-fund-rate.html
@@ -45,7 +45,7 @@
     </a>
   </div>
 </header>
-<main class="main main_template_lk">
+<main class="main main_template_lk-issues">
   <nav class="breadcrumbs">
     <ul class="breadcrumbs__list">
       <li class="breadcrumbs__item">

--- a/src/lk-fund-review.html
+++ b/src/lk-fund-review.html
@@ -47,7 +47,7 @@
       </a>
     </div>
   </header>
-  <main class="main main_template_lk">
+  <main class="main main_template_lk-issues">
     <nav class="breadcrumbs">
       <ul class="breadcrumbs__list">
         <li class="breadcrumbs__item">

--- a/src/lk-volunteer-rate.html
+++ b/src/lk-volunteer-rate.html
@@ -45,7 +45,7 @@
     </a>
   </div>
 </header>
-<main class="main main_template_lk">
+<main class="main main_template_lk-issues">
   <nav class="breadcrumbs">
     <ul class="breadcrumbs__list">
       <li class="breadcrumbs__item">

--- a/src/lk-volunteer-review.html
+++ b/src/lk-volunteer-review.html
@@ -50,7 +50,7 @@
         </div>
     </header>
 
-    <main class="main main_template_lk">
+    <main class="main main_template_lk-issues">
         <nav class="breadcrumbs">
             <ul class="breadcrumbs__list">
                 <li class="breadcrumbs__item">

--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -10,6 +10,7 @@
 @import url(../blocks/main/_template/main_template_registration-fullscreen.css);
 @import url(../blocks/main/_template/main_template_registration-form.css);
 @import url(../blocks/main/_template/main_template_first-step.css);
+@import url(../blocks/main/_template/main_template_lk-issues.css);
 
 
 
@@ -221,16 +222,15 @@
 @import url(../blocks/fieldset/__row-group/fieldset__row-group.css);
 @import url(../blocks/fieldset/__row-group/_type/fieldset__row-group_type_block.css);
 
-@import url(../blocks/fieldset/_style/fieldset_style_pb-small.css);
-@import url(../blocks/fieldset/_style/fieldset_style_p-none.css);
-@import url(../blocks/fieldset/_style/fieldset_style_wrapped.css);
-
 @import url(../blocks/fieldset/_template/fieldset_template_grid-form.css);
 @import url(../blocks/fieldset/_template/fieldset_template_grid-project-links.css);
 @import url(../blocks/fieldset/_template/fieldset_template_grid-one-col.css);
 @import url(../blocks/fieldset/_template/fieldset_template_grid-social-links.css);
 @import url(../blocks/fieldset/_template/fieldset_template_grid-rate.css);
 
+@import url(../blocks/fieldset/_style/fieldset_style_pb-small.css);
+@import url(../blocks/fieldset/_style/fieldset_style_p-none.css);
+@import url(../blocks/fieldset/_style/fieldset_style_wrapped.css);
 
 
 /* textarea */


### PR DESCRIPTION
Исправила и для десктопа тоже, так как там main_template_lk тоже увеличивал отступ сверх значения по макету.
Стили реализовала посредством новой вариации template для mane (см. файл main_template_lk-issues.css). Заменила класс main_template_lk на класс main_template_lk-issues на всех наших страницах.