### PR TITLE
fix: на страницах с выбором даты тип input изменен на date, реализова…

### DIFF
--- a/src/blocks/input/__field/_type/input__field_type_calendar.css
+++ b/src/blocks/input/__field/_type/input__field_type_calendar.css
@@ -1,7 +1,12 @@
-.input__field_type_calendar {
-
-}
-
-.input__field_type_calendar {
-
+.input__field_type_calendar::-webkit-calendar-picker-indicator {    
+    background: transparent;
+    color: transparent;
+    position: absolute;
+    bottom: 0;
+    cursor: pointer;
+    left: 0;
+    right: 0;
+    top: 0;
+    height: auto;
+    width: auto;
 }

--- a/src/components/FieldDate.js
+++ b/src/components/FieldDate.js
@@ -1,0 +1,22 @@
+export default class FieldDate {
+    constructor ({
+        inputFieldClass,
+        btnCalPickerClass
+    }) {
+        this._inputFieldClass = inputFieldClass;
+        this._btnCalPickerClass = btnCalPickerClass;       
+        this._inputFieldElement = document.querySelector(`.${this._inputFieldClass}`);
+        this._btnCalPickerElement = document.querySelector(`.${this._btnCalPickerClass}`);
+        this._handleClick = this._handleClick.bind(this);
+    }
+
+  _handleClick(evt) {
+    this._inputFieldElement.showPicker();
+  }
+
+  setEventListeners() {
+    if (this._btnCalPickerElement) {
+        this._btnCalPickerElement.addEventListener('mousedown', this._handleClick);
+    }
+  }
+}

--- a/src/components/MobileMenu.js
+++ b/src/components/MobileMenu.js
@@ -26,6 +26,8 @@ export default class MobileMenu {
 
 
   setEventListeners() {
-    this._menuBtnElement.addEventListener('mousedown', this._handleClick);
+    if (this._menuBtnElement) {
+      this._menuBtnElement.addEventListener('mousedown', this._handleClick);
+    }
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -22,7 +22,7 @@
     <li><a href="settings-change-password.html">settings-change-password.html - Страница "Настройки / Смена пароля"</a></li>
     <li><a href="settings-notifications.html">settings-notifications.html - Страница "Настройки / Уведомления"</a></li>
     <li><a href="settings-profile.html">settings-profile.html - Страница "Настройки / Профиль"</a></li>
-    <li><a href="ui-kit.html">ui-kit.html - Элементы интерфекйса</a></li>
+    <li><a href="ui-kit.html">ui-kit.html - Элементы интерфейса</a></li>
   </ul>
   <p style="font-size: 1.2em; display: flex; flex-direction: column; row-gap: 1em; padding-left: 20px">23 когорта:</p>
     <p style="font-size: 1.2em; display: flex; flex-direction: column; row-gap: 1em; padding-left: 20px">1.4. Регистрация НКО</p>

--- a/src/lk-personal-data.html
+++ b/src/lk-personal-data.html
@@ -149,12 +149,12 @@
           <span class="input__error-message">Ошибка</span>
         </div>
         <div class="input">
-          <input type="text" class="input__field input__field_type_calendar" name="date" id="date"
+          <input type="date" class="input__field input__field_type_calendar" name="date" id="date"
                  placeholder="Дата рождения"
                  required>
           <label for="date" class="input__label">Дата рождения</label>
-          <button class="btn input__btn input__btn_type_clear-text input__btn_position_first"></button>
-          <button class="btn input__btn input__btn_type_calendar"></button>
+          <button class="btn input__btn input__btn_type_clear-text input__btn_position_first" type="button"></button>
+          <button class="btn input__btn input__btn_type_calendar" type="button"></button>
           <span class="input__error-message">Ошибка</span>
         </div>
         <div class="input">

--- a/src/registration-npo-legal.html
+++ b/src/registration-npo-legal.html
@@ -133,7 +133,7 @@
           <fieldset class="fieldset fieldset_template_grid-form fieldset_style_pb-small">
             <div class="input">
               <input
-                type="text"
+                type="date"
                 class="input__field input__field_type_calendar"
                 name="registrationDate"
                 id="registrationDate"

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -22,6 +22,7 @@ import 'cropperjs';
 import Cropper from 'cropperjs';
 import PwdViewer from "../components/PwdViewer";
 import Avatar from "../components/Avatar";
+import FieldDate from '../components/FieldDate';
 
 const avatarContainer = document.querySelector('.avatar__container');
 const image = document.querySelector('.popup__image');
@@ -714,3 +715,7 @@ if (table) {
   });
 }
 
+new FieldDate({
+  inputFieldClass: 'input__field_type_calendar',
+  btnCalPickerClass: 'input__btn_type_calendar'
+}).setEventListeners();

--- a/src/ui-kit.html
+++ b/src/ui-kit.html
@@ -217,6 +217,7 @@
          required>
   <label for="date" class="input__label">Дата</label>
   <button class="btn input__btn input__btn_type_clear-text input__btn_position_first"></button>
+  <button class="btn input__btn input__btn_type_calendar" type="button"></button>
   <span class="input__error-message">Ошибка</span>
 </div>
 


### PR DESCRIPTION
1. Класс src/blocks/input/__field/_type/input__field_type_calendar.css дополнен фукнциональностью скрывать стандартный значок календаря выбора даты (в браузерах chromium)
2. На страницах, где есть выбор даты тип инпута изменен c text на date
3. На странице Личные данные кнопкам в инпуте даты явно прописан тип type=button, чтобы не было сабмита формы
4. Добавлен новый класс src/components/FieldDate.js реализующий показ формы выбора даты при нажатии на иконку календаря
5. На списке страниц исправлена опечатка в названии страницы Элементы интерфекйса - реально раздражало :-)