### PR TITLE
fix: В сгрупированных полях не работает очистка, нет кнопки очистки н…

### DIFF
--- a/src/lk-portfolio.html
+++ b/src/lk-portfolio.html
@@ -174,11 +174,12 @@
       <fieldset class="fieldset fieldset_template_grid-project-links">
         <legend class="heading heading_type_subtitle">Ссылки</legend>
         <div class="input-group">
-          <div class="input input_type_bottom-interval">
-            <input class="input__field input__field_default" type="text" placeholder="Текст ссылки">
+          <div class="input">
+            <input class="input__field input__field_default input__field_padding_center" type="text" placeholder="Текст ссылки">
+            <button class="btn input__btn input__btn_type_clear-text"></button>
           </div>
-          <div class="input input_type_bottom-interval">
-            <input class="input__field input__field_default" type="url" placeholder="https://">
+          <div class="input">
+            <input class="input__field input__field_default input__field_padding_center" type="url" placeholder="https://">
             <button class="btn input__btn input__btn_type_clear-text"></button>
           </div>
         </div>

--- a/src/ui-kit.html
+++ b/src/ui-kit.html
@@ -343,11 +343,12 @@
 <fieldset class="fieldset fieldset_template_grid-project-links">
   <legend class="heading heading_type_subtitle">Сгрупперованные поля</legend>
   <div class="input-group">
-    <div class="input input_type_bottom-interval">
-      <input class="input__field input__field_default" type="text" placeholder="Текст ссылки">
+    <div class="input">
+      <input class="input__field input__field_default input__field_padding_center" type="text" placeholder="Текст ссылки">
+      <button class="btn input__btn input__btn_type_clear-text"></button>
     </div>
-    <div class="input input_type_bottom-interval">
-      <input class="input__field input__field_default" type="url" placeholder="https://">
+    <div class="input">
+      <input class="input__field input__field_default input__field_padding_center" type="url" placeholder="https://">
       <button class="btn input__btn input__btn_type_clear-text"></button>
     </div>
   </div>


### PR DESCRIPTION
Очистка не работала на сгруппированных полях из-за доп. класса input_type_bottom-interval на обертке input поля, т.к. из-за него не отрабатывал поиск input'а в классе FieldTextCleaner:
![изображение](https://github.com/LatyshevDD/ProCharity/assets/56087999/896f4f52-ca43-4024-9b28-fccbb7400164)

Я не очень понял для чего этот класс-модификатор, удалил его - стилизация не изменилась.Очистка заработала, валидация включается только на кнопку Сохранить. 

Также добавил центрирование текста при вводе. Внес изменения на страницах Мое портфолио и Элементы интерфейса.

fix #93 