### PR TITLE
fix: добавить textarea__field прозрачный бордер (прыгает верстка)

### DIFF
--- a/src/blocks/textarea/__field/textarea__field.css
+++ b/src/blocks/textarea/__field/textarea__field.css
@@ -3,7 +3,7 @@
   -webkit-appearance: none;
   background: none;
   background: #f1f5f9;
-  border: 0;
+  border: 1px solid transparent;
   border-radius: 6px;
   box-sizing: border-box;
   color: #374045;


### PR DESCRIPTION
В стили класса textarea__field добавлен прозрачный бордер, чтобы верстка не прыгала при переходе элемента в состояние focus, для которого предусмотрено наличие бордера 1px.