### PR TITLE
fix: реализовать скругление бордера у input_type_error

### DIFF
--- a/src/blocks/input/__field/input__field.css
+++ b/src/blocks/input/__field/input__field.css
@@ -3,7 +3,7 @@
   -moz-appearance: none;
   -webkit-appearance: none;
   background: #F1F5F9;
-  border: none;
+  border: 1px solid transparent;
   border-radius: inherit;
   box-sizing: border-box;
   color: #374045;

--- a/src/blocks/input/__field/input__field.css
+++ b/src/blocks/input/__field/input__field.css
@@ -4,7 +4,7 @@
   -webkit-appearance: none;
   background: #F1F5F9;
   border: none;
-  border-radius: 6px;
+  border-radius: inherit;
   box-sizing: border-box;
   color: #374045;
   font-size: 16px;

--- a/src/blocks/input/_error/input_error.css
+++ b/src/blocks/input/_error/input_error.css
@@ -1,5 +1,0 @@
-.input_error {
-  border: 1px solid #D20202;
-  box-sizing: content-box;
-  margin-bottom: 24px;
-}

--- a/src/blocks/input/_type/input_type_error.css
+++ b/src/blocks/input/_type/input_type_error.css
@@ -1,5 +1,4 @@
 .input_type_error {
   border: 1px solid #D20202;
-  box-sizing: content-box;
   margin-bottom: 24px;
 }

--- a/src/blocks/input/input.css
+++ b/src/blocks/input/input.css
@@ -1,4 +1,5 @@
 .input {
+  border: none;
   border-radius: 6px;
   box-sizing: border-box;
   height: 48px;

--- a/src/blocks/input/input.css
+++ b/src/blocks/input/input.css
@@ -1,4 +1,5 @@
 .input {
+  border-radius: 6px;
   box-sizing: border-box;
   height: 48px;
   position: relative;

--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -247,7 +247,6 @@
 @import url(../blocks/input/__field/_padding/input__field_padding_center.css);
 @import url(../blocks/input/__field/_interval/input__field_interval_right_large.css);
 @import url(../blocks/input/__field/_interval/input__field_interval_right_small.css);
-@import url(../blocks/input/_error/input_error.css);
 @import url(../blocks/input/_type/input_type_bottom-interval.css);
 @import url(../blocks/input/__label/input__label.css);
 @import url(../blocks/input/__btn/input__btn.css);


### PR DESCRIPTION
Реализовано скругление бордера у input_type_error через наследование классом input__field от класса input, т.к. необходимо, чтобы была дифференциация скруглений в зависимости от того, одиночный это инпут или групповой (и значит скругление должно быть не со всех сторон). Скрин из макета:
![Скрин из макета](https://github.com/LatyshevDD/ProCharity/assets/124444858/45c97786-1ce0-4cbf-bda6-78c8e57c4b32)

Попутно исправлен момент, который заметила Аня - то, что по факту в проекте не отрабатывала упомянутая выше дифференциация (из-за того, что у input__field было задано скругление бордера 6px со всех сторон). Скрин из текущей версии проекта от команды 2 (к нам пришло в таком же виде):
![Скрин из текущей версии проекта команды 2](https://github.com/LatyshevDD/ProCharity/assets/124444858/a036a36b-f6c0-4dc8-808b-02ee66cbd129)

Также попутно удален класс input_error и его подключение (он, видимо, на более поздних этапах был продублирован одной из когорт и дубликат более правильный, так как соблюден нейминг по БЭМ - input_type_error):
![image](https://github.com/LatyshevDD/ProCharity/assets/124444858/4f14a029-8978-4cfe-a74d-acb2976e382e)

